### PR TITLE
fNumberS(str)をF値(float)にする処理を修正した

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const useAppStore = (): AppStore => {
   }, [focalLengthS]);
 
   useEffect(() => {
-    const f = parseInt(fNumberS, 10);
+    const f = Math.round(parseFloat(fNumberS) * 10.0) / 10.0;
     if (!isNaN(f)) {
       setFNumber(f);
     }


### PR DESCRIPTION
parseInt()は、str型で受け渡されたF値(例:1.8)について、小数点以下を切り捨てたint型のF値(例:1)に変換してしまうため、有理数(例:1.8, 2.8)であるF値を適切に処理できない。
parseFloat()を使った処理に変更することで、F値を正しく処理することができる。